### PR TITLE
Added formatter to format full lat/long string

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The MapCenterCoord control inherits options from [Leaflet Controls](http://leafl
 | latlngDesignators | Boolean | `false` | Show N-S and E-W
 | projected | Boolean | `false` | Show projected coordinates
 | formatProjected | String | `'#.##0,0'` | Number format mask for projected coordinates.<br>[JavaScript Number Formatter](https://code.google.com/p/javascript-number-formatter/) project: [sample/help page](http://www.integraxor.com/developer/codes/js-formatter/format-sample.htm )
+| latLngFormatter | Function | `undefined` | Function that takes the lattitude and longitude as arguments and returns a single formatted string, e.g.<pre>function (lat, lng) {<br>    return lat + " north and " + lng + " west";<br>}</pre>
 
 
 ## License

--- a/examples/latlng_formatter.html
+++ b/examples/latlng_formatter.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="http://xguaita.github.io/Leaflet.MapCenterCoord/dist/L.Control.MapCenterCoord.min.css" />
   <script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
   <script src="../src/L.Control.MapCenterCoord.js"></script>
+  <script src="https://cdn.rawgit.com/davetroy/geohash-js/cffd38621a27505f471493229037205f282b4397/geohash.js"></script>
   <style>
     body {
       padding: 0;
@@ -24,7 +25,7 @@
   <div id="map" class="map"></div>
 
   <script>
-    var map = L.map('map').setView([39.588, 2.935], 9);
+    var map = L.map('map').setView([43.0799, -79.0747], 9);
 
     L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
@@ -32,7 +33,9 @@
 
     L.control.mapCenterCoord({
 	  latLngFormatter: function (lat, lng) {
-	    return "location is " + lat.toFixed(4) + " north and " + lng.toFixed(4) + " west";
+	    //calculate the geo hash (to show combining lat and long); display it as a link (to show how to customise the display)
+	    var geohash = encodeGeoHash(lat, lng);
+		return '<a href="https://www.flickr.com/nearby/' + lat + ',' + lng + '?taken=alltime">' + geohash + '</a>'
 	  },
       onMove: true
     }).addTo(map);

--- a/examples/latlng_formatter.html
+++ b/examples/latlng_formatter.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Center Position Control - Single lat/lng formatter</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
+  <link rel="stylesheet" href="http://xguaita.github.io/Leaflet.MapCenterCoord/dist/L.Control.MapCenterCoord.min.css" />
+  <script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+  <script src="../src/L.Control.MapCenterCoord.js"></script>
+  <style>
+    body {
+      padding: 0;
+      margin: 0;
+    }
+    html, body, #map {
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div id="map" class="map"></div>
+
+  <script>
+    var map = L.map('map').setView([39.588, 2.935], 9);
+
+    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    L.control.mapCenterCoord({
+	  latLngFormatter: function (lat, lng) {
+	    return "location is " + lat.toFixed(4) + " north and " + lng.toFixed(4) + " west";
+	  },
+      onMove: true
+    }).addTo(map);
+  </script>
+</body>
+
+</html>

--- a/src/L.Control.MapCenterCoord.js
+++ b/src/L.Control.MapCenterCoord.js
@@ -8,7 +8,8 @@ L.Control.MapCenterCoord = L.Control.extend({
     projected: false,
     formatProjected: '#.##0,000',
     latlngFormat: 'DD', // DD, DM, DMS
-    latlngDesignators: false
+    latlngDesignators: false,
+    latLngFormatter: undefined
   },
 
   onAdd: function (map) {
@@ -86,6 +87,9 @@ L.Control.MapCenterCoord = L.Control.extend({
 
 
   _getLatLngCoord: function (center) {
+
+    if (this.options.latLngFormatter != undefined) return this.options.latLngFormatter(center.lat, center.lng);
+
     var lat, lng, deg, min;
 
     // 180 degrees & negative


### PR DESCRIPTION
This pull request adds the ability to specify a formatter that formats the lat/long as a whole.

This can be useful when using unusual/custom coordinate systems and projections.

NB: the diff makes it look like many lines have changed but most of them are just indentation changes.
